### PR TITLE
Add denisdefreyne.com

### DIFF
--- a/sites/denisdefreyne.com.md
+++ b/sites/denisdefreyne.com.md
@@ -1,0 +1,8 @@
+---
+title: 'Denis Defreyne'
+url: 'https://denisdefreyne.com'
+tags: ['software developer', 'weeknotes writer', 'fiction writer']
+updatesFeed: 'https://denisdefreyne.com/feeds/weeknotes.xml'
+nsfw: false
+rss: true
+---


### PR DESCRIPTION
This adds my own personal web site, https://denisdefreyne.com. Thanks!

I got here through [Sophie Koonin’s talk at ffconf 2022](https://ffconf.org/talks/2022_type__error_talk/) by the way!