### PR TITLE
chore: remove an offline website

### DIFF
--- a/sites/eleven.codes.md
+++ b/sites/eleven.codes.md
@@ -1,7 +1,0 @@
----
-title: 'Eleven'
-url: 'https://eleven.codes'
-tags: ['student', 'developer', 'svelte']
-nsfw: false
-rss: false
----


### PR DESCRIPTION
Removes an offline website. 

@elevenski: I see you added https://eleven.js.org [a while back](https://github.com/themaxgross/personalsit.es/commit/90f85e0b067b75a3e4e97b2a642e30265d7f8285) -- I'm guessing that's your new one?