### PR TITLE
Add Michal Hornak portfolio

### DIFF
--- a/sites/portfolio.michalhornak.site.md
+++ b/sites/portfolio.michalhornak.site.md
@@ -1,0 +1,5 @@
+---
+title: 'Michal Hornák'
+url: 'https://portfolio.michalhornak.site/'
+tags: ['developer', 'portfolio']
+---


### PR DESCRIPTION
Adds Michal Hornak’s personal portfolio to the site directory.

- URL: https://portfolio.michalhornak.site/
- Tags: developer, portfolio

No automated validation was run; this is a metadata-only site entry.